### PR TITLE
Same return type for validators

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,15 +76,15 @@ backend source). This makes them a no brainer to test, compose and reuse across 
 Simple synchronous validation:
 
 ```ts
-const isHello = value => value !== "hello" ? { hello: true } : null;
+const isHello = value => value !== "hello" ? { hello: true } : {};
 ```
 
 If you need multiple error messages simply add new properties to the errors object:
 
 ```ts
 import { combine } from "mobx-form-reactions";
-const startsWithA = value => value[0] !== "A" ? { startsWithA: true } : null;
-const containsNumber = value => !/\d/.test(value) ? { containsNumber: true } : null;
+const startsWithA = value => value[0] !== "A" ? { startsWithA: true } : {};
+const containsNumber = value => !/\d/.test(value) ? { containsNumber: true } : {};
 
 const validate = combine(startsWithA, containsNumber);
 
@@ -108,10 +108,10 @@ function checkApi(value: any) {
     .then(res => res.json())
     .then(res => {
       if (res.status > 300) {
-        return { response: 300 };
+        return { response: res.status };
       }
 
-      return null;
+      return {};
     });
 }
 ```

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -84,17 +84,13 @@ export interface ValidationError {
   [error: string]: any;
 }
 
-export type ValidationResult = ValidationError | null;
-export type Validator<T> = (value: T) => ValidationResult | Promise<ValidationResult>;
+export type Validator<T> = (value: T) => ValidationError | Promise<ValidationError>;
 ```
-
-We do return `null` on success, because `null` is cheaper to construct compared
-to an `Object`.
 
 And a custom `Validator`:
 
 ```ts
-const foo = value => value === "foo" ? null : { foo: true };
+const foo = value => value === "foo" ? {} : { foo: true };
 ```
 
 This design choice is heavily inspired by Angular 2's awesome `reactive-forms`

--- a/examples/match-passwords.ts
+++ b/examples/match-passwords.ts
@@ -8,7 +8,7 @@ interface PasswordGroup {
 export const matchPasswords = (fields: PasswordGroup) => {
   return fields.password.value !== fields.confirmPassword.value
     ? { matchPasswords: true }
-    : null;
+    : {};
 };
 
 const options = { validator: matchPasswords };

--- a/src/Field.ts
+++ b/src/Field.ts
@@ -1,5 +1,5 @@
 import { action, computed, observable } from "mobx";
-import { AbstractFormControl, FieldOptions, Validator, ValidationResult, ValidationError } from "./shapes";
+import { AbstractFormControl, FieldOptions, Validator, ValidationError } from "./shapes";
 
 export default class Field implements AbstractFormControl {
   validator: Validator<any>;
@@ -68,7 +68,7 @@ export default class Field implements AbstractFormControl {
     }
 
     this.validating = true;
-    return (result as Promise<ValidationResult>).then(this.stopValidation);
+    return (result as Promise<ValidationError>).then(this.stopValidation);
   }
 
   // Cannot work inside startValidation function because of strict mode.

--- a/src/FormGroup.ts
+++ b/src/FormGroup.ts
@@ -10,7 +10,6 @@ import {
 } from "./shapes";
 
 export default class FormGroup<T> implements AbstractFormControl {
-  name: "";
   validator: Validator<any>;
   @observable errors: ValidationError = {};
   @observable fields: T;

--- a/src/__tests__/Field.spec.ts
+++ b/src/__tests__/Field.spec.ts
@@ -1,6 +1,6 @@
 import { assert as t } from "chai";
 import { useStrict, toJS } from "mobx";
-import { Validator, ValidationResult } from "../shapes";
+import { Validator, ValidationError } from "../shapes";
 import Field from "../Field";
 
 useStrict(true);
@@ -20,7 +20,7 @@ describe("Field", () => {
 
   it("should validate synchronously", () => {
     const field = new Field("foo", {
-      validator: value => value !== "hello" ? { hello: true } : null,
+      validator: value => value !== "hello" ? { hello: true } : {},
     });
 
     field.setValue("nope");
@@ -35,10 +35,10 @@ describe("Field", () => {
   });
 
   it("should validate asynchronously", () => {
-    const validator: Validator<any> = (value: string): Promise<ValidationResult> => {
-      return new Promise<ValidationResult>(res => {
+    const validator: Validator<any> = (value: string): Promise<ValidationError> => {
+      return new Promise<ValidationError>(res => {
         setTimeout(() => {
-          return res(value !== "hello" ? { nope: true } : null);
+          return res(value !== "hello" ? { nope: true } : {});
         }, 10);
       });
     };
@@ -50,7 +50,6 @@ describe("Field", () => {
     return field.setValue("nope")
       .then(() => {
         t.equal(field.valid, false);
-        // t.equal(field.errorCount, 1);
         t.equal(field.initial, false);
       });
   });

--- a/src/__tests__/FormGroup.spec.ts
+++ b/src/__tests__/FormGroup.spec.ts
@@ -44,7 +44,7 @@ describe("Form", () => {
   it("should reset the FormGroup", () => {
     const isHello = (value: string) => value !== "hello"
       ? { hello: true }
-      : null;
+      : {};
 
     const foo = new Field({ validator: isHello });
     const form = new FormGroup({ foo });

--- a/src/__tests__/utils.spec.ts
+++ b/src/__tests__/utils.spec.ts
@@ -26,14 +26,22 @@ import { combineAsync, combine } from "../utils";
 //   });
 // });
 
-const isABC = (value: string) => value !== "ABC" ? { isABC: true } : null;
-const isABCAsync = (value: string) => Promise.resolve(isABC(value));
-const startsWithA = (value: string) => value[0] !== "A" ? { startsWithA: true } : null;
+interface IIsABC {
+  abc?: boolean;
+}
+
+interface IStartsWithA {
+  startsWithA?: boolean;
+}
+
+const isABC = (value: any) => value !== "ABC" ? { isABC: true } : {};
+const isABCAsync = (value: any) => Promise.resolve(isABC(value));
+const startsWithA = (value: string) => value[0] !== "A" ? { startsWithA: true } : {};
 const startsWithAAsync = (value: string) => Promise.resolve(startsWithA(value));
 
 describe("combine", () => {
   it("should run synchronous validations", () => {
-    const validate = combine(isABC, startsWithA);
+    const validate = combine<IIsABC & IStartsWithA>(isABC, startsWithA);
     t.deepEqual(validate("nope"), {
       isABC: true,
       startsWithA: true,
@@ -43,7 +51,7 @@ describe("combine", () => {
 
 describe("combineAsync", () => {
   it("should work with synchronous validations", () => {
-    const validate = combineAsync(isABC, startsWithA);
+    const validate = combineAsync<IIsABC & IStartsWithA>(isABC, startsWithA);
 
     return validate("nope")
       .then(res => t.deepEqual(res, {
@@ -53,7 +61,7 @@ describe("combineAsync", () => {
   });
 
   it("should work with asynchronous validations", () => {
-    const validate = combineAsync(isABCAsync, startsWithAAsync);
+    const validate = combineAsync<IIsABC & IStartsWithA>(isABCAsync, startsWithAAsync);
 
     return validate("nope")
       .then(res => t.deepEqual(res, {
@@ -63,7 +71,7 @@ describe("combineAsync", () => {
   });
 
   it("should work with mixed synchronous and asynchronous", () => {
-    const validate = combineAsync(isABC, startsWithAAsync);
+    const validate = combineAsync<IIsABC & IStartsWithA>(isABC, startsWithAAsync);
 
     return validate("nope")
       .then(res => t.deepEqual(res, {

--- a/src/__tests__/validations.spec.ts
+++ b/src/__tests__/validations.spec.ts
@@ -11,9 +11,9 @@ describe("required", () => {
   });
 
   it("should succeed if value is present", () => {
-    t.deepEqual(required("a"), null);
-    t.deepEqual(required([1]), null);
-    t.deepEqual(required({ foo: 1 }), null);
+    t.deepEqual(required("a"), {});
+    t.deepEqual(required([1]), {});
+    t.deepEqual(required({ foo: 1 }), {});
   });
 });
 
@@ -27,9 +27,9 @@ describe("minLength", () => {
   });
 
   it("should succeed if value is >= min", () => {
-    t.equal(minLength(2)("aa"), null);
-    t.equal(minLength(2)("aaa"), null);
-    t.equal(minLength(2)([1, 3, 4]), null);
+    t.deepEqual(minLength(2)("aa"), {});
+    t.deepEqual(minLength(2)("aaa"), {});
+    t.deepEqual(minLength(2)([1, 3, 4]), {});
   });
 });
 
@@ -43,9 +43,9 @@ describe("maxLength", () => {
   });
 
   it("should succeed if value is <= max", () => {
-    t.equal(maxLength(2)("aa"), null);
-    t.equal(maxLength(2)("a"), null);
-    t.equal(maxLength(2)([4]), null);
+    t.deepEqual(maxLength(2)("aa"), {});
+    t.deepEqual(maxLength(2)("a"), {});
+    t.deepEqual(maxLength(2)([4]), {});
   });
 });
 
@@ -58,7 +58,7 @@ describe("pattern", () => {
   });
 
   it("should succeed if value is <= max", () => {
-    t.equal(pattern(/foo/g)("foo"), null);
+    t.deepEqual(pattern(/foo/g)("foo"), {});
   });
 });
 
@@ -71,7 +71,7 @@ describe("range", () => {
   });
 
   it("should succeed if value is <= max", () => {
-    t.equal(range(1, 4)(2), null);
-    t.equal(range(1, 4)(3), null);
+    t.deepEqual(range(1, 4)(2), {});
+    t.deepEqual(range(1, 4)(3), {});
   });
 });

--- a/src/shapes.ts
+++ b/src/shapes.ts
@@ -27,5 +27,4 @@ export interface ValidationError {
   [error: string]: any;
 }
 
-export type ValidationResult = ValidationError | null;
-export type Validator<T> = (value: T) => ValidationResult | Promise<ValidationResult>;
+export type Validator<T> = (value: T) => ValidationError | Promise<ValidationError>;

--- a/src/validations.ts
+++ b/src/validations.ts
@@ -19,33 +19,33 @@ const isRange = (min: number, max: number) => (value: any) =>
   !isNullOrUndef(value) && value >= min && value <= max;
 
 // Validators
-export const required = (value: any): ValidationError | null =>
-  !isRequired(value) ? { required: true } : null;
+export const required = (value: any): ValidationError =>
+  !isRequired(value) ? { required: true } : {};
 
 export interface IMinLength {
-  minLength: boolean;
+  minLength?: boolean;
 }
 
-export const minLength = (min: number) => (value: any): IMinLength | null =>
-  !isMinLength(min)(value) ? { minLength: true } : null;
+export const minLength = (min: number) => (value: any): IMinLength =>
+  !isMinLength(min)(value) ? { minLength: true } : {};
 
 export interface IMaxLength {
-  maxLength: boolean;
+  maxLength?: boolean;
 }
 
-export const maxLength = (max: number) => (value: any): IMaxLength | null =>
-  !isMaxLength(max)(value) ? { maxLength: true } : null;
+export const maxLength = (max: number) => (value: any): IMaxLength =>
+  !isMaxLength(max)(value) ? { maxLength: true } : {};
 
 export interface IPattern {
-  pattern: boolean;
+  pattern?: boolean;
 }
 
-export const pattern = (regex: RegExp) => (value: any): IPattern | null =>
-  !isPattern(regex)(value) ? { pattern: true } : null;
+export const pattern = (regex: RegExp) => (value: any): IPattern =>
+  !isPattern(regex)(value) ? { pattern: true } : {};
 
 export interface IRange {
-  range: boolean;
+  range?: boolean;
 }
 
-export const range = (min: number, max: number) => (value: any): IRange | null =>
-  !isRange(min, max)(value) ? { range: true } : null;
+export const range = (min: number, max: number) => (value: any): IRange =>
+  !isRange(min, max)(value) ? { range: true } : {};


### PR DESCRIPTION
Always return the same type from `Validators`.

Todos:
- [x] Align `Validator` return types
- [x] update `README` and `Docs`