### PR TITLE
Add BooleanFIeld class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## next
+
+Add new `BooleanField` field class as a child class of `Field`. Only difference is
+that its default value is `false`, the validator is set to `isBoolean` and
+that it has a handy `toggle()` method.
+
 ## 3.2.0
 
 - Fix `defaultValue` not beeing used correctly if it was set to `false`

--- a/src/BooleanField.ts
+++ b/src/BooleanField.ts
@@ -1,0 +1,34 @@
+import { action } from "mobx";
+import Field from "./Field";
+import { isBoolean } from "./validations";
+import { BooleanFieldOptions, ControlOptions } from "./shapes";
+
+export default class BooleanField extends Field {
+  constructor(options?: BooleanFieldOptions);
+  constructor(defaultValue: boolean, options?: BooleanFieldOptions);
+  constructor(defaultValue?: boolean | BooleanFieldOptions, options?: BooleanFieldOptions) {
+    if (typeof defaultValue === "undefined") {
+      options = {};
+      defaultValue = false;
+    } else if (typeof defaultValue !== "boolean") {
+      options = defaultValue;
+      defaultValue = false;
+    }
+
+    (options as ControlOptions).validator = isBoolean;
+    super(defaultValue as boolean, options);
+  }
+
+  @action.bound toggle() {
+    this.initial = false;
+    if (this._value === null || typeof this._value === "undefined") {
+      if (typeof this.defaultValue === "boolean") {
+        this._value = !this.defaultValue;
+      } else {
+        this._value = true;
+      }
+    } else {
+      this._value = !this._value;
+    }
+  }
+}

--- a/src/__tests__/BooleanField.spec.ts
+++ b/src/__tests__/BooleanField.spec.ts
@@ -1,0 +1,22 @@
+import { assert as t } from "chai";
+import BooleanField from "../BooleanField";
+
+describe("Checkbox", () => {
+  it("should instantiate with default Options", () => {
+    const field = new BooleanField();
+    t.equal(field.defaultValue, false);
+    t.equal(typeof field.validator, "function");
+
+    const field2 = new BooleanField(true, { disabled: true });
+    t.equal(field2.defaultValue, true);
+    t.equal(field2.disabled, true);
+  });
+
+  it("should toggle", () => {
+    const field = new BooleanField();
+    t.equal(field.value, false);
+
+    field.toggle();
+    t.equal(field.value, true);
+  });
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,7 @@
 export { default as Field } from "./Field";
 export { default as FormGroup } from "./FormGroup";
 export { default as FieldArray } from "./FieldArray";
+export { default as BooleanField } from "./BooleanField";
 export * from "./utils";
 export * from "./shapes";
 export * from "./validations";

--- a/src/shapes.ts
+++ b/src/shapes.ts
@@ -23,6 +23,10 @@ export interface ControlOptions {
   validator?: Validator<any>;
 }
 
+export interface BooleanFieldOptions {
+  disabled?: boolean;
+}
+
 export interface ValidationError {
   [error: string]: any;
 }


### PR DESCRIPTION
<!-- Describe the feature or fix here -->

Add new `Checkbox` field class as a child class of `Field`. Only difference is that its default value is `false`, the validator is set to `isBoolean` and it has a `toggle()` method.

**EDIT:** Renamed to `BooleanField`. The name Checkbox is too closely tied to a specific ui element.

Tasks:

- [x] Added tests
- [x] Updated `README` and `CHANGELOG`
