### PR TITLE
Fix error in BooleanField constructor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## next
+
+- Fix error when only setting `defaultValue` in `BooleanField` constructor
+
 ## 3.3.0
 
 Add new `BooleanField` field class as a child class of `Field`. Only difference is

--- a/src/BooleanField.ts
+++ b/src/BooleanField.ts
@@ -13,6 +13,8 @@ export default class BooleanField extends Field {
     } else if (typeof defaultValue !== "boolean") {
       options = defaultValue;
       defaultValue = false;
+    } else if (typeof options === "undefined") {
+      options = {};
     }
 
     (options as ControlOptions).validator = isBoolean;

--- a/src/__tests__/BooleanField.spec.ts
+++ b/src/__tests__/BooleanField.spec.ts
@@ -10,6 +10,10 @@ describe("Checkbox", () => {
     const field2 = new BooleanField(true, { disabled: true });
     t.equal(field2.defaultValue, true);
     t.equal(field2.disabled, true);
+
+    const field3 = new BooleanField(true);
+    t.equal(field3.defaultValue, true);
+    t.equal(field3.disabled, false);
   });
 
   it("should toggle", () => {


### PR DESCRIPTION
<!-- Describe the feature or fix here -->

The constructor would throw an error if not passed with an options object.

Tasks:

- [x] Added tests
- [x] Updated `README` and `CHANGELOG`
