### PR TITLE
Bound actions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## next
+
+- Bind `this` for all actions
+
 ## 3.3.2
 
 - Fix missing action decorator in `FieldArray` validation

--- a/src/Field.ts
+++ b/src/Field.ts
@@ -43,14 +43,14 @@ export default class Field implements AbstractFormControl {
     return this._value;
   }
 
-  @action reset() {
+  @action.bound reset() {
     this.initial = true;
     this._value = null;
     this.errors = {};
     this.validating = false;
   }
 
-  @action setValue(value: any, skipValidation?: boolean) {
+  @action.bound setValue(value: any, skipValidation?: boolean) {
     this.initial = false;
     this._value = value;
 
@@ -59,11 +59,11 @@ export default class Field implements AbstractFormControl {
     }
   }
 
-  @action setDefaultValue(value: any) {
+  @action.bound setDefaultValue(value: any) {
     this.defaultValue = value;
   }
 
-  @action setDisabled(value: boolean) {
+  @action.bound setDisabled(value: boolean) {
     this.disabled = value;
   }
 

--- a/src/FieldArray.ts
+++ b/src/FieldArray.ts
@@ -71,24 +71,24 @@ export default class FieldArray implements AbstractFormControl {
       });
   }
 
-  @action removeAt(index: number) {
+  @action.bound removeAt(index: number) {
     this.fields.splice(index, 1);
   }
 
-  @action insert(index: number, field: AbstractFormControl) {
+  @action.bound insert(index: number, field: AbstractFormControl) {
     this.fields.splice(index, 0, field);
   }
 
-  @action push(...fields: AbstractFormControl[]) {
+  @action.bound push(...fields: AbstractFormControl[]) {
     this.fields.push(...fields);
   }
 
-  @action reset() {
+  @action.bound reset() {
     this.fields.forEach(field => field.reset());
     this.errors = {};
   }
 
-  @action submit(): Object {
+  @action.bound submit(): Object {
     if (this.disabled) {
       return [];
     }

--- a/src/FormGroup.ts
+++ b/src/FormGroup.ts
@@ -58,7 +58,7 @@ export default class FormGroup<T extends FieldCache> implements AbstractFormCont
     return Object.keys(this.fields);
   }
 
-  @action setValidating(value: boolean) {
+  @action.bound setValidating(value: boolean) {
     this._validating = value;
   }
 
@@ -66,7 +66,7 @@ export default class FormGroup<T extends FieldCache> implements AbstractFormCont
     this.disabled = value;
   }
 
-  @action reset() {
+  @action.bound reset() {
     const keys = Object.keys(this.fields);
     for (const key of keys) {
       (this.fields as any)[key].reset();

--- a/src/__tests__/BooleanField.spec.ts
+++ b/src/__tests__/BooleanField.spec.ts
@@ -22,5 +22,11 @@ describe("Checkbox", () => {
 
     field.toggle();
     t.equal(field.value, true);
+
+    const field2 = new BooleanField(false);
+    t.equal(field2.value, false);
+
+    field2.toggle();
+    t.equal(field2.value, true);
   });
 });

--- a/src/__tests__/utils.spec.ts
+++ b/src/__tests__/utils.spec.ts
@@ -2,30 +2,6 @@ import { assert as t } from "chai";
 import { action, computed, observable } from "mobx";
 import { combineAsync, combine } from "../utils";
 
-// describe("createFormModel", () => {
-//   it("should create a view model with observable keys", () => {
-//     class Model {
-//       @observable name: string = null;
-//       @observable surname: string = null;
-
-//       @computed get fullName() {
-//         return this.name + " " + this.surname;
-//       }
-
-//       @action doSomething() {
-//         this.surname = Math.random() + "";
-//       }
-//     }
-
-//     const model = new Model();
-
-//     console.log((Object as any).getOwnPropertyDescriptors(model));
-
-//     console.log(model);
-//     console.log(Object.keys(model));
-//   });
-// });
-
 interface IIsABC {
   abc?: boolean;
 }


### PR DESCRIPTION
<!-- Describe the feature or fix here -->
Bind all actions to force correct ´this` reference when methods are used in event listeners.

Tasks:

- [x] Added tests
- [x] Updated `README` and `CHANGELOG`
