### PR TITLE
Update dependencies (mobx)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 3.4.0
+
+Upgrade `mobx` to `3.1.0` which allows modifying non-observed members
+without being wrapped with `action`. This is extremely useful
+for initialization in constructors. Also up the version number
+because the removal of `action` will now throw an error on older
+versions of mobx.
+
 ## 3.3.4
 
 - `required` validation should trim `strings`

--- a/package.json
+++ b/package.json
@@ -21,19 +21,19 @@
     "prepublish": "npm run lint && npm t && npm run build"
   },
   "dependencies": {
-    "mobx": "^3.0.2"
+    "mobx": "^3.1.0"
   },
   "devDependencies": {
     "@types/chai": "^3.4.34",
-    "@types/mocha": "^2.2.36",
+    "@types/mocha": "^2.2.39",
     "babel-cli": "^6.22.2",
     "babel-preset-es2015": "^6.22.0",
     "chai": "^3.5.0",
     "mocha": "^3.2.0",
-    "nyc": "^10.0.0",
+    "nyc": "^10.1.2",
     "rimraf": "^2.5.4",
     "ts-node": "^2.0.0",
-    "tslint": "^4.3.1",
+    "tslint": "^4.4.2",
     "typescript": "^2.1.5"
   },
   "nyc": {

--- a/src/Field.ts
+++ b/src/Field.ts
@@ -19,10 +19,8 @@ export default class Field implements AbstractFormControl {
       defaultValue = null;
     }
 
-    action("init", () => {
-      this.defaultValue = defaultValue;
-      Object.assign(this, options);
-    })();
+    this.defaultValue = defaultValue;
+    Object.assign(this, options);
   }
 
   @computed get valid() {

--- a/src/FieldArray.ts
+++ b/src/FieldArray.ts
@@ -15,11 +15,9 @@ export default class FieldArray implements AbstractFormControl {
       this.push(...fields);
     }
 
-    action(() => {
-      if (options) {
-        Object.assign(this, options);
-      }
-    })();
+    if (options) {
+      Object.assign(this, options);
+    }
   }
 
   @computed get valid() {

--- a/src/FormGroup.ts
+++ b/src/FormGroup.ts
@@ -18,12 +18,10 @@ export default class FormGroup<T extends FieldCache> implements AbstractFormCont
   @observable private _validating: boolean = false;
 
   constructor(fields: T, options?: ControlOptions) {
-    action("init", () => {
-      this.fields = fields;
-      if (options) {
-        Object.assign(this, options);
-      }
-    })();
+    this.fields = fields;
+    if (options) {
+      Object.assign(this, options);
+    }
   }
 
   @computed get valid() {

--- a/yarn.lock
+++ b/yarn.lock
@@ -6,9 +6,9 @@
   version "3.4.34"
   resolved "https://registry.yarnpkg.com/@types/chai/-/chai-3.4.34.tgz#d5335792823bb09cddd5e38c3d211b709183854d"
 
-"@types/mocha@^2.2.36":
-  version "2.2.38"
-  resolved "https://registry.yarnpkg.com/@types/mocha/-/mocha-2.2.38.tgz#8c188f6e34c2e7c3f1d0127d908d5a36e5a60dc9"
+"@types/mocha@^2.2.39":
+  version "2.2.39"
+  resolved "https://registry.yarnpkg.com/@types/mocha/-/mocha-2.2.39.tgz#f68d63db8b69c38e9558b4073525cf96c4f7a829"
 
 abbrev@1:
   version "1.0.9"
@@ -1616,9 +1616,9 @@ mkdirp@0.5.1, "mkdirp@>=0.5 0", mkdirp@^0.5.0, mkdirp@^0.5.1, mkdirp@~0.5.1:
   dependencies:
     minimist "0.0.8"
 
-mobx@^3.0.2:
-  version "3.0.2"
-  resolved "https://registry.yarnpkg.com/mobx/-/mobx-3.0.2.tgz#ade8e83434f7a73868d2632603b6d17da530427c"
+mobx@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/mobx/-/mobx-3.1.0.tgz#e5f15b475efdd1eea1f5c43a0afccde6e6f322ee"
 
 mocha@^3.2.0:
   version "3.2.0"
@@ -1694,7 +1694,7 @@ number-is-nan@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/number-is-nan/-/number-is-nan-1.0.1.tgz#097b602b53422a522c1afb8790318336941a011d"
 
-nyc@^10.0.0:
+nyc@^10.1.2:
   version "10.1.2"
   resolved "https://registry.yarnpkg.com/nyc/-/nyc-10.1.2.tgz#ea7acaa20a235210101604f4e7d56d28453b0274"
   dependencies:
@@ -2155,10 +2155,6 @@ spdx-license-ids@^1.0.2:
   version "1.2.2"
   resolved "https://registry.yarnpkg.com/spdx-license-ids/-/spdx-license-ids-1.2.2.tgz#c9df7a3424594ade6bd11900d596696dc06bac57"
 
-sprintf-js@^1.0.3:
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/sprintf-js/-/sprintf-js-1.0.3.tgz#04e6926f662895354f3dd015203633b857297e2c"
-
 sshpk@^1.7.0:
   version "1.10.2"
   resolved "https://registry.yarnpkg.com/sshpk/-/sshpk-1.10.2.tgz#d5a804ce22695515638e798dbe23273de070a5fa"
@@ -2295,9 +2291,9 @@ tsconfig@^5.0.2:
     strip-bom "^2.0.0"
     strip-json-comments "^2.0.0"
 
-tslint@^4.3.1:
-  version "4.3.1"
-  resolved "https://registry.yarnpkg.com/tslint/-/tslint-4.3.1.tgz#28f679c53ca4b273688bcb6fcf0dde7ff1bb2169"
+tslint@^4.4.2:
+  version "4.4.2"
+  resolved "https://registry.yarnpkg.com/tslint/-/tslint-4.4.2.tgz#b14cb79ae039c72471ab4c2627226b940dda19c6"
   dependencies:
     babel-code-frame "^6.20.0"
     colors "^1.1.2"
@@ -2306,7 +2302,6 @@ tslint@^4.3.1:
     glob "^7.1.1"
     optimist "~0.6.0"
     resolve "^1.1.7"
-    underscore.string "^3.3.4"
     update-notifier "^1.0.2"
 
 tunnel-agent@~0.4.1:
@@ -2346,13 +2341,6 @@ uid-number@~0.0.6:
   version "0.0.6"
   resolved "https://registry.yarnpkg.com/uid-number/-/uid-number-0.0.6.tgz#0ea10e8035e8eb5b8e4449f06da1c730663baa81"
 
-underscore.string@^3.3.4:
-  version "3.3.4"
-  resolved "https://registry.yarnpkg.com/underscore.string/-/underscore.string-3.3.4.tgz#2c2a3f9f83e64762fdc45e6ceac65142864213db"
-  dependencies:
-    sprintf-js "^1.0.3"
-    util-deprecate "^1.0.2"
-
 unzip-response@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/unzip-response/-/unzip-response-1.0.2.tgz#b984f0877fc0a89c2c773cc1ef7b5b232b5b06fe"
@@ -2380,7 +2368,7 @@ user-home@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/user-home/-/user-home-1.1.1.tgz#2b5be23a32b63a7c9deb8d0f28d485724a3df190"
 
-util-deprecate@^1.0.2, util-deprecate@~1.0.1:
+util-deprecate@~1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/util-deprecate/-/util-deprecate-1.0.2.tgz#450d4dc9fa70de732762fbd2d4a28981419a0ccf"
 


### PR DESCRIPTION
<!-- Describe the feature or fix here -->
Update to mobx 3.1.0 which allows changing class members inside a constructor without action.

Tasks:

- [x] Added tests
- [x] Updated `README` and `CHANGELOG`
