### PR TITLE
Revisions + strict mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 4.1.0
+
+* Add back support for `enforceActions` (previously called `useStrict()` in mobx)
+* Add support for revisions for forms. This is great for dirty checking/syncing
+* Make `validator`-property on `Field` non-private to allow setting Validators with circular references
+* Add setter for `initial`-property and don't set it to false upon calling `setValue`. This is needed because ux requirements differ quite a bit about when a validation error should be shown to the user the first time
+
 ## 4.0.0
 
 * **Breaking:** Rename package to `@marvinh/mobx-form-reactions`

--- a/README.md
+++ b/README.md
@@ -32,6 +32,17 @@ Additional classes:
 interface AbstractControl {
   /** List of error strings */
   errors: string[];
+  /**
+   * Incremented each time a field is changed. Useful for dirty-checking or
+   * syncing requirements
+   */
+  revision: number;
+  /**
+   * Control is marked as being pristine. This is usually used to customize
+   * the behaviour when errors should be shown the first time
+   */
+  initial: boolean;
+  /** Marks control as being disabled */
   disabled: boolean;
   /** The current state of the field */
   status: "valid" | "pending" | "invalid";

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@marvinh/mobx-form-reactions",
-  "version": "4.0.0",
+  "version": "4.1.0",
   "description": "MobX form state classes",
   "main": "dist/cjs/index.js",
   "module": "dist/es/index.js",

--- a/src/Field.ts
+++ b/src/Field.ts
@@ -50,8 +50,12 @@ export class Field implements AbstractFormControl {
 
   @action.bound
   setValue(value: FieldValue) {
-    this.initial = false;
     this.value = value;
+  }
+
+  @action.bound
+  setInitial(value: boolean) {
+    this.initial = value;
   }
 
   @action.bound

--- a/src/Field.ts
+++ b/src/Field.ts
@@ -6,6 +6,7 @@ export type FieldValue = string | number | boolean | null;
 
 export interface FieldOptions extends ControlOptions<Field> {
   value?: FieldValue;
+  revision?: number;
 }
 
 export class Field implements AbstractFormControl {
@@ -14,6 +15,7 @@ export class Field implements AbstractFormControl {
   @observable disabled: boolean = false;
   @observable _validating: boolean = false;
   @observable value: FieldValue;
+  @observable revision: number = 0;
 
   validator: IValidator<Field>;
   defaultValue: FieldValue;
@@ -21,12 +23,14 @@ export class Field implements AbstractFormControl {
   constructor({
     value = null,
     disabled = false,
+    revision = 0,
     validator = new Validator(),
   }: FieldOptions = {}) {
     this.validator = validator;
     this.defaultValue = value;
     this.value = value;
     this.disabled = disabled;
+    this.revision = revision;
   }
 
   @computed
@@ -45,12 +49,14 @@ export class Field implements AbstractFormControl {
     this.value = this.defaultValue;
     this.errors = [];
     this._validating = false;
+    this.revision = 0;
     return this.validate().then(() => undefined);
   }
 
   @action.bound
   setValue(value: FieldValue) {
     this.value = value;
+    this.revision++;
   }
 
   @action.bound

--- a/src/Field.ts
+++ b/src/Field.ts
@@ -15,8 +15,8 @@ export class Field implements AbstractFormControl {
   @observable _validating: boolean = false;
   @observable value: FieldValue;
 
-  private validator: IValidator<Field>;
-  private defaultValue: FieldValue;
+  validator: IValidator<Field>;
+  defaultValue: FieldValue;
 
   constructor({
     value = null,

--- a/src/FieldArray.ts
+++ b/src/FieldArray.ts
@@ -23,6 +23,11 @@ export class FieldArray implements AbstractFormControl {
   }
 
   @computed
+  get initial() {
+    return this.fields.every(x => x.initial);
+  }
+
+  @computed
   get revision() {
     return this.fields.reduce((rev, x) => (rev += x.revision), 0);
   }

--- a/src/FieldArray.ts
+++ b/src/FieldArray.ts
@@ -23,6 +23,11 @@ export class FieldArray implements AbstractFormControl {
   }
 
   @computed
+  get revision() {
+    return this.fields.reduce((rev, x) => (rev += x.revision), 0);
+  }
+
+  @computed
   get status() {
     if (this.errors.length > 0) return FieldStatus.INVALID;
     if (this._validating) return FieldStatus.PENDING;

--- a/src/FieldArray.ts
+++ b/src/FieldArray.ts
@@ -8,7 +8,7 @@ export class FieldArray implements AbstractFormControl {
   @observable _validating: boolean = false;
   @observable fields: AbstractFormControl[] = [];
   @observable errors: string[] = [];
-  private validator: IValidator<FieldArray>;
+  validator: IValidator<FieldArray>;
 
   constructor(
     fields: AbstractFormControl[] = [],

--- a/src/FormGroup.ts
+++ b/src/FormGroup.ts
@@ -4,7 +4,7 @@ import { getStatus } from "./utils";
 import { Validator, IValidator } from "./Validator";
 
 export class FormGroup<T extends object> implements AbstractFormControl {
-  private validator: IValidator<FormGroup<T>>;
+  validator: IValidator<FormGroup<T>>;
   @observable disabled: boolean = false;
   @observable errors: string[] = [];
   @observable fields: T;

--- a/src/FormGroup.ts
+++ b/src/FormGroup.ts
@@ -23,6 +23,11 @@ export class FormGroup<T extends object> implements AbstractFormControl {
   }
 
   @computed
+  get initial() {
+    return this.allFields.every(x => x.initial);
+  }
+
+  @computed
   get revision() {
     return this.allFields.reduce((rev, x) => (rev += x.revision), 0);
   }

--- a/src/FormGroup.ts
+++ b/src/FormGroup.ts
@@ -23,6 +23,11 @@ export class FormGroup<T extends object> implements AbstractFormControl {
   }
 
   @computed
+  get revision() {
+    return this.allFields.reduce((rev, x) => (rev += x.revision), 0);
+  }
+
+  @computed
   get status() {
     if (this.errors.length > 0) return FieldStatus.INVALID;
     if (this._validating) return FieldStatus.PENDING;

--- a/src/__tests__/Field.spec.ts
+++ b/src/__tests__/Field.spec.ts
@@ -16,6 +16,9 @@ describe("Field", () => {
     const field3 = new Field({ value: "foo", disabled: true });
     t.equal(field3.disabled, true);
     t.equal(field3.value, "foo");
+
+    const field4 = new Field({ revision: 10 });
+    t.equal(field4.revision, 10);
   });
 
   it("should set initial value", () => {
@@ -83,6 +86,13 @@ describe("Field", () => {
     t.equal(field.value, "foo");
     t.equal(field.status, FieldStatus.VALID);
     t.equal(field.initial, true);
+    t.equal(field.revision, 0);
+  });
+
+  it("should track revision", () => {
+    const f = new Field();
+    f.setValue("123");
+    t.equal(f.revision, 1);
   });
 
   it("should set disabled", () => {

--- a/src/__tests__/Field.spec.ts
+++ b/src/__tests__/Field.spec.ts
@@ -1,9 +1,11 @@
 import * as t from "assert";
-import { toJS } from "mobx";
+import { toJS, configure } from "mobx";
 import { FieldStatus } from "../shapes";
 import { Field } from "../Field";
 import { SyncValidateFn, AsyncValidateFn, Validator } from "..";
 import { isHello, delay } from "./helpers";
+
+configure({ enforceActions: true });
 
 describe("Field", () => {
   it("should set options", () => {

--- a/src/__tests__/Field.spec.ts
+++ b/src/__tests__/Field.spec.ts
@@ -18,6 +18,14 @@ describe("Field", () => {
     t.equal(field3.value, "foo");
   });
 
+  it("should set initial value", () => {
+    const field = new Field();
+    t.equal(field.initial, true);
+
+    field.setInitial(false);
+    t.equal(field.initial, false);
+  });
+
   it("should validate synchronously", async () => {
     const field = new Field({
       value: "foo",
@@ -31,7 +39,7 @@ describe("Field", () => {
     t.deepEqual(toJS(field.errors), ["hello"]);
 
     field.setValue("hello");
-    field.validate();
+    await field.validate();
     t.equal(field.status, FieldStatus.VALID);
   });
 
@@ -51,15 +59,12 @@ describe("Field", () => {
 
     await field.validate();
     t.equal(field.status, FieldStatus.INVALID);
-    t.equal(field.initial, false);
   });
 
   it("should set value", () => {
     const field = new Field({ value: "foo" });
     field.setValue("hey");
-
     t.equal(field.value, "hey");
-    t.equal(field.initial, false);
   });
 
   it("should get fall back to defaultValue when empty", () => {
@@ -70,6 +75,7 @@ describe("Field", () => {
   it("should reset a field", () => {
     const field = new Field({ value: "foo" });
     field.setValue("baz");
+    field.setInitial(false);
 
     t.equal(field.initial, false);
 

--- a/src/__tests__/FieldArray.spec.ts
+++ b/src/__tests__/FieldArray.spec.ts
@@ -1,10 +1,12 @@
 import * as t from "assert";
-import { toJS } from "mobx";
+import { toJS, configure } from "mobx";
 import { asyncIsHello, isHello } from "./helpers";
 import { FieldArray } from "../FieldArray";
 import { FormGroup } from "../FormGroup";
 import { Field } from "../Field";
 import { FieldStatus, Validator } from "..";
+
+configure({ enforceActions: true });
 
 describe("FieldArray", () => {
   it("should add fields via constructor", () => {

--- a/src/__tests__/FieldArray.spec.ts
+++ b/src/__tests__/FieldArray.spec.ts
@@ -51,6 +51,7 @@ describe("FieldArray", () => {
     form.push(foo);
 
     foo.setValue("nope");
+    foo.setInitial(false);
     t.equal(foo.initial, false);
 
     await form.validate();

--- a/src/__tests__/FieldArray.spec.ts
+++ b/src/__tests__/FieldArray.spec.ts
@@ -86,6 +86,18 @@ describe("FieldArray", () => {
     t.deepEqual(form.value, []);
   });
 
+  it("should track revision", () => {
+    const f = new Field();
+    const f2 = new Field();
+    const form = new FieldArray([f, f2]);
+
+    f.setValue("123");
+    t.equal(form.revision, 1);
+
+    f2.setValue(123);
+    t.equal(form.revision, 2);
+  });
+
   it("should check if fields are disabled", () => {
     const form = new FieldArray([
       new Field(),

--- a/src/__tests__/FieldArray.spec.ts
+++ b/src/__tests__/FieldArray.spec.ts
@@ -14,6 +14,21 @@ describe("FieldArray", () => {
     t.equal(form.fields.length, 1);
   });
 
+  it("should track initial state", () => {
+    const f1 = new Field();
+    const f2 = new Field();
+    const form = new FieldArray([f1, f2]);
+
+    t.equal(form.initial, true);
+
+    f1.setInitial(false);
+    t.equal(form.initial, false);
+
+    f1.setInitial(true);
+    f2.setInitial(false);
+    t.equal(form.initial, false);
+  });
+
   it("should push new elements", () => {
     const foo = new Field();
     const form = new FieldArray();

--- a/src/__tests__/FormGroup.spec.ts
+++ b/src/__tests__/FormGroup.spec.ts
@@ -29,6 +29,21 @@ describe("FormGroup", () => {
     t.equal(form2.disabled, true);
   });
 
+  it("should track initial", () => {
+    const fa = new Field();
+    const fb = new Field();
+    const form = new FormGroup({ fa, fb });
+
+    t.equal(form.initial, true);
+
+    fa.setInitial(false);
+    t.equal(form.initial, false);
+
+    fa.setInitial(true);
+    fb.setInitial(false);
+    t.equal(form.initial, false);
+  });
+
   it("should return valid if fields are valid", () => {
     const fa = new Field();
     const fb = new Field();

--- a/src/__tests__/FormGroup.spec.ts
+++ b/src/__tests__/FormGroup.spec.ts
@@ -35,6 +35,18 @@ describe("FormGroup", () => {
     t.equal(form.status, FieldStatus.VALID);
   });
 
+  it("should track revision", () => {
+    const f = new Field();
+    const f2 = new Field();
+    const form = new FormGroup({ foo: f, bar: f2 });
+
+    f.setValue("123");
+    t.equal(form.revision, 1);
+
+    f2.setValue("bob");
+    t.equal(form.revision, 2);
+  });
+
   it("should return invalid if one field is invalid", async () => {
     const fa = new Field();
     const fb = new Field({ validator: new Validator({ sync: [isHello] }) });

--- a/src/__tests__/FormGroup.spec.ts
+++ b/src/__tests__/FormGroup.spec.ts
@@ -1,10 +1,12 @@
 import * as t from "assert";
-import { toJS } from "mobx";
+import { toJS, configure } from "mobx";
 import { asyncIsHello, isHello } from "./helpers";
 import { Field } from "../Field";
 import { FormGroup } from "../FormGroup";
 import { FieldArray } from "../FieldArray";
 import { FieldStatus, AsyncValidateFn, Validator } from "..";
+
+configure({ enforceActions: true });
 
 describe("FormGroup", () => {
   it("should initialize via constructor", () => {

--- a/src/shapes.ts
+++ b/src/shapes.ts
@@ -12,6 +12,7 @@ export interface AbstractFormControl {
   _validating: boolean;
   status: FieldStatus;
   value: any;
+  revision: number;
   reset(): Promise<void>;
   validate(): Promise<void>;
   setDisabled(value: boolean): void;

--- a/src/shapes.ts
+++ b/src/shapes.ts
@@ -12,6 +12,7 @@ export interface AbstractFormControl {
   _validating: boolean;
   status: FieldStatus;
   value: any;
+  initial: boolean;
   revision: number;
   reset(): Promise<void>;
   validate(): Promise<void>;


### PR DESCRIPTION
* Add back support for `enforceActions` (previously called `useStrict()` in mobx)
* Add support for revisions for forms. This is great for dirty checking/syncing
* Make `validator`-property on `Field` non-private to allow setting Validators with circular references
* Add setter for `initial`-property and don't set it to false upon calling `setValue`. This is needed because ux requirements differ quite a bit about when a validation error should be shown to the user the first time

Tasks:

- [x] Added tests
- [x] Updated `README` and `CHANGELOG`
