### PR TITLE
Prevent babel from transpiling for-of loops to generators

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## next
+
+* Prevent babel from transpiling `for-of` loops with generators.
+
 ## 4.1.0
 
 * Add back support for `enforceActions` (previously called `useStrict()` in mobx)

--- a/src/FieldArray.ts
+++ b/src/FieldArray.ts
@@ -14,8 +14,8 @@ export class FieldArray implements AbstractFormControl {
     fields: AbstractFormControl[] = [],
     {
       disabled = false,
-      validator = new Validator(),
-    }: ControlOptions<FieldArray> = {},
+      validator = new Validator()
+    }: ControlOptions<FieldArray> = {}
   ) {
     this.disabled = disabled;
     this.validator = validator;
@@ -44,7 +44,9 @@ export class FieldArray implements AbstractFormControl {
     if (this.disabled) return [];
 
     const out = [];
-    for (const field of this.fields) {
+    // tslint:disable-next-line:prefer-for-of
+    for (let i = 0; i < this.fields.length; i++) {
+      const field = this.fields[i];
       if (!field.disabled) out.push(field.value);
     }
     return out;

--- a/src/FormGroup.ts
+++ b/src/FormGroup.ts
@@ -14,8 +14,8 @@ export class FormGroup<T extends object> implements AbstractFormControl {
     fields: T,
     {
       validator = new Validator(),
-      disabled = false,
-    }: ControlOptions<FormGroup<T>> = {},
+      disabled = false
+    }: ControlOptions<FormGroup<T>> = {}
   ) {
     this.fields = fields;
     this.validator = validator;
@@ -64,7 +64,9 @@ export class FormGroup<T extends object> implements AbstractFormControl {
 
   @action.bound
   reset() {
-    for (const field of this.allFields) {
+    // tslint:disable-next-line:prefer-for-of
+    for (let i = 0; i < this.allFields.length; i++) {
+      const field = this.allFields[i];
       field.reset();
     }
 

--- a/src/Validator.ts
+++ b/src/Validator.ts
@@ -1,7 +1,7 @@
 import {
   CancelController,
   AbortedErrorMsg,
-  throwIfAborted,
+  throwIfAborted
 } from "@marvinh/cancel-token";
 import { AbstractFormControl } from "./shapes";
 
@@ -27,7 +27,7 @@ export class Validator<T extends AbstractFormControl> implements IValidator<T> {
   constructor({
     sync = [],
     async = [],
-    bailFirstError = true,
+    bailFirstError = true
   }: ValidatorOptions<T> = {}) {
     this.sync = sync;
     this.async = async;
@@ -41,7 +41,13 @@ export class Validator<T extends AbstractFormControl> implements IValidator<T> {
     control.errors = [];
 
     if (this.sync.length > 0) {
-      for (const fn of this.sync) {
+      // Use a standard for loop, because babel can't transpile it to a for-loop
+      // because of missing type information and will attempt to use a generator
+      // polyfill combined with symbols instead. This always leads to undefined
+      // errors in IE with the cryptic message: `Object expected`.
+      // tslint:disable-next-line:prefer-for-of
+      for (let i = 0; i < this.sync.length; i++) {
+        const fn = this.sync[i];
         const res = fn(control);
         if (res !== undefined) {
           control.errors.push(res);
@@ -55,7 +61,9 @@ export class Validator<T extends AbstractFormControl> implements IValidator<T> {
     if (this.async.length > 0) {
       control._validating = true;
       try {
-        for (const fn of this.async) {
+        // tslint:disable-next-line:prefer-for-of
+        for (let i = 0; i < this.async.length; i++) {
+          const fn = this.async[i];
           if (this.bailFirstError && control.errors.length > 0) return;
           const res = await fn(control);
           throwIfAborted(controller.signal);

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -3,7 +3,9 @@ import { AbstractFormControl, FieldStatus } from "./shapes";
 export function getStatus(fields: AbstractFormControl[]) {
   let pending = false;
 
-  for (const field of fields) {
+  // tslint:disable-next-line:prefer-for-of
+  for (let i = 0; i < fields.length; i++) {
+    const field = fields[i];
     if (field.status === FieldStatus.INVALID) {
       return FieldStatus.INVALID;
     } else if (field.status === FieldStatus.PENDING) {


### PR DESCRIPTION
This PR fixes an issue where babel would always throw an exception when our code is transpiled down to es5. This is due to an undefined error caused by the generator polyfill.

Because babel only operates on javascript and doesn't have the luxury of dealing with proper types like TypeScript does, it can't prove that we are only iterating over an array. Compare the following links:

- [Babel](https://babeljs.io/repl/#?babili=false&browsers=&build=&builtIns=false&code_lz=MYewdgzgLgBARjAvDA2gRgDQwEwF0BQ-AZiAE4wAUoksAhjCEfAJQwDe-MM1EIANgFMAdHxABzCrWYBufAF8gA&debug=false&forceAllTransforms=false&shippedProposals=false&circleciRepo=&evaluate=false&fileSize=false&lineWrap=true&presets=es2015%2Creact%2Cstage-2&prettier=false&targets=&version=6.26.0&envVersion=)
- [TypeScript](https://www.typescriptlang.org/play/#src=const%20b%20%3D%20%5B1%2C%202%5D%0A%0Afor%20(const%20a%20of%20b)%20%7B%0A%20%20console.log(a)%3B%0A%7D)

Tasks:

- [x] Added tests
- [x] Updated `README` and `CHANGELOG`
